### PR TITLE
add runtime type checking helper

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,3 @@
 {
-  "presets": [
-    "es2015",
-    "stage-0"
-  ],
-  "plugins": [
-    "transform-runtime",
-    "transform-object-rest-spread"
-  ]
+  "plugins": ["transform-es2015-modules-simple-commonjs"]
 }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # Every-Fn
 
-Javascript function that iterates over an array of functions until one of the functions returns `false`. The output of each function is merged into the output of the previously called function and passed as input to the next function call.
+Nano package that exports two functions: `every` and `typed`.
 
-An optional initial state object may be provided.
+---
 
-If an asynchronous function is specified, `Every-Fn` will `await` it's return before calling the next function.
+## Every
 
-### Example
+`every` is a function that iterates over an list of functions until one of the functions returns `false`. The output of each function is merged into the output of the previously called function and passed as input to the next function call.
 
-`sample-controller.js`
+An optional initial state object may be provided as a second argument.
+
+If an asynchronous function is specified, `every` will `await` it's return before calling the next function.
+
+For example: `sample-controller.js`
 
 ```
 import { every } from "every-fn";
@@ -17,19 +21,21 @@ import {
   sendValidationErrors,
   cleanUserInput,
   findCustomer,
-  sendCustomerError,
-  sendLoginSuccess
+  handleDbError,
+  sendCustomerExistsError,
+  sendLoginSuccessResponse
 } from "./lib/customer-login.js";
 
 export const loginCustomer = async (req, res) =>
-  await everyFn(
+  await every(
     [
       validateInput,
       sendValidationErrors,
       cleanUserInput,
       findCustomer,
-      sendCustomerError,
-      sendLoginSuccess
+      handleDbError,
+      sendCustomerExistsError,
+      sendLoginSuccessResponse
     ],
     { req, res }
   );
@@ -37,7 +43,11 @@ export const loginCustomer = async (req, res) =>
 
 ---
 
-### Example of Defining a Function With Runtime Type Checking
+### Typed
+
+The `typed` function is a helper that uses [ObjectModel](http://objectmodel.js.org/) for performing runtime type-checking.
+
+For example `lib/some-lib.js`
 
 ```
 import { typed } from "every-fn";
@@ -51,4 +61,19 @@ const { count } = nameLength({ name: "Javascript" });
 
 nameLength({ name: 100 });
 // TypeError: expecting arguments[0].name to be String, got Number 100
+```
+
+For async functions, don't check the return value, just pass two arguments:
+
+```
+typed(
+    { name: String },
+    async ({ name }) => ({
+      count: await new Promise(resolve =>
+        setTimeout(() => {
+          resolve(name.length);
+        }, 100)
+      )
+    })
+  )
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-Every-Fn
-========
+# Every-Fn
 
-Javascript function that iterates over an array of functions until one of the functions returns `false`. The output of each function is combined and passed as input to the next function call.
+Javascript function that iterates over an array of functions until one of the functions returns `false`. The output of each function is merged into the output of the previously called function and passed as input to the next function call.
 
 An optional initial state object may be provided.
 
-If an asynchronous function is specified, `Every-Fn` will await it's response before calling the next function.
+If an asynchronous function is specified, `Every-Fn` will `await` it's return before calling the next function.
 
 ### Example
-`controller.js`
+
+`sample-controller.js`
+
 ```
+import { every } from "every-fn";
 import {
   validateInput,
   sendValidationErrors,
@@ -31,4 +33,22 @@ export const loginCustomer = async (req, res) =>
     ],
     { req, res }
   );
+```
+
+---
+
+### Example of Defining a Function With Runtime Type Checking
+
+```
+import { typed } from "every-fn";
+
+export const nameLength = typed({ name: String }, { count: Number }, ({ name }) => ({
+  count: name.length
+}));
+
+const { count } = nameLength({ name: "Javascript" });
+// assert.equal(count, 10);
+
+nameLength({ name: 100 });
+// TypeError: expecting arguments[0].name to be String, got Number 100
 ```

--- a/dist/index.js
+++ b/dist/index.js
@@ -18,4 +18,4 @@ const every = exports.every = async (functions, initialState = {}) => {
   return finalState[1];
 };
 
-const typed = exports.typed = (typeIn, typeOut, fn) => FunctionModel(Model(typeIn)).return(Model(typeOut))(fn);
+const typed = exports.typed = (typeIn, typeOut, fn) => fn === undefined ? FunctionModel(Model(typeIn))(typeOut) : FunctionModel(Model(typeIn)).return(Model(typeOut))(fn);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,144 +1,21 @@
-(function (global, factory) {
-  if (typeof define === "function" && define.amd) {
-    define(["exports", "babel-runtime/core-js/promise", "babel-runtime/helpers/slicedToArray", "babel-runtime/regenerator", "babel-runtime/helpers/asyncToGenerator", "babel-runtime/core-js/object/assign", "babel-runtime/helpers/typeof"], factory);
-  } else if (typeof exports !== "undefined") {
-    factory(exports, require("babel-runtime/core-js/promise"), require("babel-runtime/helpers/slicedToArray"), require("babel-runtime/regenerator"), require("babel-runtime/helpers/asyncToGenerator"), require("babel-runtime/core-js/object/assign"), require("babel-runtime/helpers/typeof"));
-  } else {
-    var mod = {
-      exports: {}
-    };
-    factory(mod.exports, global.promise, global.slicedToArray, global.regenerator, global.asyncToGenerator, global.assign, global._typeof);
-    global.index = mod.exports;
-  }
-})(this, function (exports, _promise, _slicedToArray2, _regenerator, _asyncToGenerator2, _assign, _typeof2) {
-  "use strict";
+"use strict";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
-  });
+var _objectmodel = require("objectmodel");
 
-  var _promise2 = _interopRequireDefault(_promise);
+var FunctionModel = _objectmodel.FunctionModel;
+var Model = _objectmodel.Model;
 
-  var _slicedToArray3 = _interopRequireDefault(_slicedToArray2);
 
-  var _regenerator2 = _interopRequireDefault(_regenerator);
+const handleReturnValue = (value, prevState) => typeof value === "object" ? [true, Object.assign({}, prevState, value)] : [value === false ? false : true, prevState];
 
-  var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
+const callFunction = async (fn, state) => handleReturnValue((await fn(state)), state);
 
-  var _assign2 = _interopRequireDefault(_assign);
+const every = exports.every = async (functions, initialState = {}) => {
+  const finalState = await functions.reduce(async (previousPromise, fn) => {
+    const [doNext, state] = await previousPromise;
+    return doNext ? await callFunction(fn, state) : [false, state];
+  }, Promise.resolve([true, initialState]));
+  return finalState[1];
+};
 
-  var _typeof3 = _interopRequireDefault(_typeof2);
-
-  function _interopRequireDefault(obj) {
-    return obj && obj.__esModule ? obj : {
-      default: obj
-    };
-  }
-
-  var handleReturnValue = function handleReturnValue(value, prevState) {
-    return (typeof value === "undefined" ? "undefined" : (0, _typeof3.default)(value)) === "object" ? [true, (0, _assign2.default)({}, prevState, value)] : [value === false ? false : true, prevState];
-  };
-
-  var callFunction = function () {
-    var _ref = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee(fn, state) {
-      return _regenerator2.default.wrap(function _callee$(_context) {
-        while (1) {
-          switch (_context.prev = _context.next) {
-            case 0:
-              _context.t0 = handleReturnValue;
-              _context.next = 3;
-              return fn(state);
-
-            case 3:
-              _context.t1 = _context.sent;
-              _context.t2 = state;
-              return _context.abrupt("return", (0, _context.t0)(_context.t1, _context.t2));
-
-            case 6:
-            case "end":
-              return _context.stop();
-          }
-        }
-      }, _callee, undefined);
-    }));
-
-    return function callFunction(_x, _x2) {
-      return _ref.apply(this, arguments);
-    };
-  }();
-
-  exports.default = function () {
-    var _ref2 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee3(functions) {
-      var initialState = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-      var finalState;
-      return _regenerator2.default.wrap(function _callee3$(_context3) {
-        while (1) {
-          switch (_context3.prev = _context3.next) {
-            case 0:
-              _context3.next = 2;
-              return functions.reduce(function () {
-                var _ref3 = (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee2(previousPromise, fn) {
-                  var _ref4, _ref5, doNext, state;
-
-                  return _regenerator2.default.wrap(function _callee2$(_context2) {
-                    while (1) {
-                      switch (_context2.prev = _context2.next) {
-                        case 0:
-                          _context2.next = 2;
-                          return previousPromise;
-
-                        case 2:
-                          _ref4 = _context2.sent;
-                          _ref5 = (0, _slicedToArray3.default)(_ref4, 2);
-                          doNext = _ref5[0];
-                          state = _ref5[1];
-
-                          if (!doNext) {
-                            _context2.next = 12;
-                            break;
-                          }
-
-                          _context2.next = 9;
-                          return callFunction(fn, state);
-
-                        case 9:
-                          _context2.t0 = _context2.sent;
-                          _context2.next = 13;
-                          break;
-
-                        case 12:
-                          _context2.t0 = [false, state];
-
-                        case 13:
-                          return _context2.abrupt("return", _context2.t0);
-
-                        case 14:
-                        case "end":
-                          return _context2.stop();
-                      }
-                    }
-                  }, _callee2, undefined);
-                }));
-
-                return function (_x5, _x6) {
-                  return _ref3.apply(this, arguments);
-                };
-              }(), _promise2.default.resolve([true, initialState]));
-
-            case 2:
-              finalState = _context3.sent;
-              return _context3.abrupt("return", finalState[1]);
-
-            case 4:
-            case "end":
-              return _context3.stop();
-          }
-        }
-      }, _callee3, undefined);
-    }));
-
-    return function (_x3) {
-      return _ref2.apply(this, arguments);
-    };
-  }();
-});
+const typed = exports.typed = (typeIn, typeOut, fn) => FunctionModel(Model(typeIn)).return(Model(typeOut))(fn);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "every-fn",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,248 +1,9 @@
 {
     "name": "every-fn",
-    "version": "1.0.0",
+    "version": "1.0.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@babel/code-frame": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-            "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-            "dev": true,
-            "requires": {
-                "@babel/highlight": "7.0.0-beta.44"
-            }
-        },
-        "@babel/generator": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "7.0.0-beta.44",
-                "jsesc": "2.5.1",
-                "lodash": "4.17.10",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
-            },
-            "dependencies": {
-                "jsesc": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-                    "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-                    "dev": true
-                }
-            }
-        },
-        "@babel/helper-function-name": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-            "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-get-function-arity": "7.0.0-beta.44",
-                "@babel/template": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44"
-            }
-        },
-        "@babel/helper-get-function-arity": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-            "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "7.0.0-beta.44"
-            }
-        },
-        "@babel/helper-split-export-declaration": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-            "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "7.0.0-beta.44"
-            }
-        },
-        "@babel/highlight": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-            "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-            "dev": true,
-            "requires": {
-                "chalk": "2.4.1",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "3.0.0"
-                    }
-                }
-            }
-        },
-        "@babel/template": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-            "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
-                "lodash": "4.17.10"
-            },
-            "dependencies": {
-                "babylon": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-                    "dev": true
-                }
-            }
-        },
-        "@babel/traverse": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-            "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/generator": "7.0.0-beta.44",
-                "@babel/helper-function-name": "7.0.0-beta.44",
-                "@babel/helper-split-export-declaration": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
-                "debug": "3.1.0",
-                "globals": "11.4.0",
-                "invariant": "2.2.4",
-                "lodash": "4.17.10"
-            },
-            "dependencies": {
-                "babylon": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-                    "dev": true
-                },
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "globals": {
-                    "version": "11.4.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-                    "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
-                    "dev": true
-                }
-            }
-        },
-        "@babel/types": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-            "dev": true,
-            "requires": {
-                "esutils": "2.0.2",
-                "lodash": "4.17.10",
-                "to-fast-properties": "2.0.0"
-            },
-            "dependencies": {
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
-            }
-        },
-        "acorn": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-            "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
-            "dev": true
-        },
-        "acorn-jsx": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-            "dev": true,
-            "requires": {
-                "acorn": "3.3.0"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-                    "dev": true
-                }
-            }
-        },
-        "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-            "dev": true,
-            "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-            }
-        },
-        "ajv-keywords": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-            "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-            "dev": true
-        },
-        "align-text": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-            "dev": true,
-            "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
-            }
-        },
-        "ansi-escapes": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-            "dev": true
-        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -262,17 +23,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "micromatch": "2.3.11",
-                "normalize-path": "2.1.1"
-            }
-        },
-        "argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "requires": {
-                "sprintf-js": "1.0.3"
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
             }
         },
         "arr-diff": {
@@ -282,7 +34,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1"
             }
         },
         "arr-flatten": {
@@ -292,33 +44,12 @@
             "dev": true,
             "optional": true
         },
-        "array-union": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true,
-            "requires": {
-                "array-uniq": "1.0.3"
-            }
-        },
-        "array-uniq": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
-        },
         "array-unique": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
             "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
             "dev": true,
             "optional": true
-        },
-        "arrify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-            "dev": true
         },
         "assert": {
             "version": "1.4.1",
@@ -342,21 +73,21 @@
             "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
             "dev": true,
             "requires": {
-                "babel-core": "6.26.2",
-                "babel-polyfill": "6.26.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "chokidar": "1.7.0",
-                "commander": "2.15.1",
-                "convert-source-map": "1.5.1",
-                "fs-readdir-recursive": "1.1.0",
-                "glob": "7.1.2",
-                "lodash": "4.17.10",
-                "output-file-sync": "1.1.2",
-                "path-is-absolute": "1.0.1",
-                "slash": "1.0.0",
-                "source-map": "0.5.7",
-                "v8flags": "2.1.1"
+                "babel-core": "^6.26.0",
+                "babel-polyfill": "^6.26.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "chokidar": "^1.6.1",
+                "commander": "^2.11.0",
+                "convert-source-map": "^1.5.0",
+                "fs-readdir-recursive": "^1.0.0",
+                "glob": "^7.1.2",
+                "lodash": "^4.17.4",
+                "output-file-sync": "^1.1.2",
+                "path-is-absolute": "^1.0.1",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.6",
+                "v8flags": "^2.1.1"
             }
         },
         "babel-code-frame": {
@@ -365,9 +96,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
         "babel-core": {
@@ -376,47 +107,25 @@
             "integrity": "sha512-rFKFnHY8sbRSqja2O5eTx0z0Na5hukdtsFt7X9xdBFXMurrJ5YoY78Y/2/EuNZIaDQKEJSfxSMePfsymxt0CZg==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.1",
-                "babel-helpers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "convert-source-map": "1.5.1",
-                "debug": "2.6.9",
-                "json5": "0.5.1",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.8",
-                "slash": "1.0.0",
-                "source-map": "0.5.7"
-            }
-        },
-        "babel-eslint": {
-            "version": "8.2.3",
-            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
-            "integrity": "sha512-0HeSTtaXg/Em7FCUWxwOT+KeFSO1O7LuRuzhk7g+1BjwdlQGlHq4OyMi3GqGxrNfEq8jEi6Hmt5ylEQUhurgiQ==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/traverse": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "1.0.0"
-            },
-            "dependencies": {
-                "babylon": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-                    "dev": true
-                }
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
             }
         },
         "babel-generator": {
@@ -425,164 +134,14 @@
             "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
             "dev": true,
             "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.10",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
-            }
-        },
-        "babel-helper-bindify-decorators": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
-            "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-builder-binary-assignment-operator-visitor": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-            "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-            "dev": true,
-            "requires": {
-                "babel-helper-explode-assignable-expression": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-call-delegate": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-            "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-            "dev": true,
-            "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-define-map": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-            "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
-            }
-        },
-        "babel-helper-explode-assignable-expression": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-            "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-explode-class": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
-            "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-            "dev": true,
-            "requires": {
-                "babel-helper-bindify-decorators": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-function-name": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-            "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-            "dev": true,
-            "requires": {
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-get-function-arity": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-            "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-hoist-variables": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-            "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-optimise-call-expression": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-            "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-regex": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-            "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
-            }
-        },
-        "babel-helper-remap-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-replace-supers": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-            "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-            "dev": true,
-            "requires": {
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
             }
         },
         "babel-helpers": {
@@ -591,8 +150,8 @@
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-messages": {
@@ -601,440 +160,19 @@
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
-        "babel-plugin-check-es2015-constants": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-            "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+        "babel-plugin-transform-es2015-modules-simple-commonjs": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-simple-commonjs/-/babel-plugin-transform-es2015-modules-simple-commonjs-0.3.0.tgz",
+            "integrity": "sha1-wV71BpZ8Hui3KQzt7Nukr2WB7h4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-syntax-async-functions": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-            "dev": true
-        },
-        "babel-plugin-syntax-async-generators": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-            "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
-            "dev": true
-        },
-        "babel-plugin-syntax-class-constructor-call": {
-            "version": "6.18.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-            "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
-            "dev": true
-        },
-        "babel-plugin-syntax-class-properties": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-            "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
-            "dev": true
-        },
-        "babel-plugin-syntax-decorators": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-            "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
-            "dev": true
-        },
-        "babel-plugin-syntax-do-expressions": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
-            "integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0=",
-            "dev": true
-        },
-        "babel-plugin-syntax-dynamic-import": {
-            "version": "6.18.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-            "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
-            "dev": true
-        },
-        "babel-plugin-syntax-exponentiation-operator": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-            "dev": true
-        },
-        "babel-plugin-syntax-export-extensions": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-            "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
-            "dev": true
-        },
-        "babel-plugin-syntax-function-bind": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
-            "integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
-            "dev": true
-        },
-        "babel-plugin-syntax-object-rest-spread": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-            "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-            "dev": true
-        },
-        "babel-plugin-syntax-trailing-function-commas": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-            "dev": true
-        },
-        "babel-plugin-transform-async-generator-functions": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-            "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-            "dev": true,
-            "requires": {
-                "babel-helper-remap-async-to-generator": "6.24.1",
-                "babel-plugin-syntax-async-generators": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-            "dev": true,
-            "requires": {
-                "babel-helper-remap-async-to-generator": "6.24.1",
-                "babel-plugin-syntax-async-functions": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-class-constructor-call": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
-            "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-class-constructor-call": "6.18.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-class-properties": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-            "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-plugin-syntax-class-properties": "6.13.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-decorators": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
-            "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-            "dev": true,
-            "requires": {
-                "babel-helper-explode-class": "6.24.1",
-                "babel-plugin-syntax-decorators": "6.13.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-do-expressions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
-            "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-do-expressions": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-arrow-functions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-            "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-block-scoped-functions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-            "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-            "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
-            }
-        },
-        "babel-plugin-transform-es2015-classes": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-            "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-            "dev": true,
-            "requires": {
-                "babel-helper-define-map": "6.26.0",
-                "babel-helper-function-name": "6.24.1",
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-computed-properties": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-            "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-            "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-duplicate-keys": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-            "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-for-of": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-            "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-function-name": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-            "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-literals": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-            "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-amd": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-            "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-            "version": "6.26.2",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-            "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-strict-mode": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-systemjs": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-            "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-            "dev": true,
-            "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-umd": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-            "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-object-super": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-            "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-            "dev": true,
-            "requires": {
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-parameters": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-            "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-            "dev": true,
-            "requires": {
-                "babel-helper-call-delegate": "6.24.1",
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-            "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-spread": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-            "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-sticky-regex": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-            "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-            "dev": true,
-            "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-template-literals": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-            "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-            "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-unicode-regex": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-            "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-            "dev": true,
-            "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "regexpu-core": "2.0.0"
-            }
-        },
-        "babel-plugin-transform-exponentiation-operator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-            "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-            "dev": true,
-            "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-export-extensions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
-            "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-export-extensions": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-function-bind": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
-            "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-function-bind": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-object-rest-spread": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-            "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-object-rest-spread": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-regenerator": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-            "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-            "dev": true,
-            "requires": {
-                "regenerator-transform": "0.10.1"
+                "babel-plugin-transform-strict-mode": "^6.8.0",
+                "babel-runtime": "^6.3.19",
+                "babel-template": "^6.3.13",
+                "better-log": "^1.3.1"
             }
         },
         "babel-plugin-transform-runtime": {
@@ -1043,7 +181,7 @@
             "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-strict-mode": {
@@ -1052,17 +190,8 @@
             "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-plugin-uglify": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/babel-plugin-uglify/-/babel-plugin-uglify-1.0.2.tgz",
-            "integrity": "sha1-17zasTKvutsL80eaVmbrjeCCYQ8=",
-            "dev": true,
-            "requires": {
-                "uglify-js": "2.8.29"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-polyfill": {
@@ -1071,9 +200,9 @@
             "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.5",
-                "regenerator-runtime": "0.10.5"
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "regenerator-runtime": "^0.10.5"
             },
             "dependencies": {
                 "regenerator-runtime": {
@@ -1084,98 +213,19 @@
                 }
             }
         },
-        "babel-preset-es2015": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-            "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-check-es2015-constants": "6.22.0",
-                "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-                "babel-plugin-transform-es2015-classes": "6.24.1",
-                "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-                "babel-plugin-transform-es2015-destructuring": "6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-                "babel-plugin-transform-es2015-for-of": "6.23.0",
-                "babel-plugin-transform-es2015-function-name": "6.24.1",
-                "babel-plugin-transform-es2015-literals": "6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-                "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-                "babel-plugin-transform-es2015-object-super": "6.24.1",
-                "babel-plugin-transform-es2015-parameters": "6.24.1",
-                "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-                "babel-plugin-transform-es2015-spread": "6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-                "babel-plugin-transform-es2015-template-literals": "6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.26.0"
-            }
-        },
-        "babel-preset-stage-0": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
-            "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-do-expressions": "6.22.0",
-                "babel-plugin-transform-function-bind": "6.22.0",
-                "babel-preset-stage-1": "6.24.1"
-            }
-        },
-        "babel-preset-stage-1": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
-            "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-class-constructor-call": "6.24.1",
-                "babel-plugin-transform-export-extensions": "6.22.0",
-                "babel-preset-stage-2": "6.24.1"
-            }
-        },
-        "babel-preset-stage-2": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
-            "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-dynamic-import": "6.18.0",
-                "babel-plugin-transform-class-properties": "6.24.1",
-                "babel-plugin-transform-decorators": "6.24.1",
-                "babel-preset-stage-3": "6.24.1"
-            }
-        },
-        "babel-preset-stage-3": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
-            "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-                "babel-plugin-transform-async-generator-functions": "6.24.1",
-                "babel-plugin-transform-async-to-generator": "6.24.1",
-                "babel-plugin-transform-exponentiation-operator": "6.24.1",
-                "babel-plugin-transform-object-rest-spread": "6.26.0"
-            }
-        },
         "babel-register": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "dev": true,
             "requires": {
-                "babel-core": "6.26.2",
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.5",
-                "home-or-tmp": "2.0.0",
-                "lodash": "4.17.10",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.4.18"
+                "babel-core": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "home-or-tmp": "^2.0.0",
+                "lodash": "^4.17.4",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.15"
             }
         },
         "babel-runtime": {
@@ -1184,8 +234,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "2.5.5",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
             }
         },
         "babel-template": {
@@ -1194,11 +244,11 @@
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "lodash": "4.17.10"
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-traverse": {
@@ -1207,15 +257,15 @@
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.4",
-                "lodash": "4.17.10"
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
             }
         },
         "babel-types": {
@@ -1224,10 +274,10 @@
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.10",
-                "to-fast-properties": "1.0.3"
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
             }
         },
         "babylon": {
@@ -1240,6 +290,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "better-log": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/better-log/-/better-log-1.3.3.tgz",
+            "integrity": "sha1-IZocA4Oo+cRBaJfto6z5tNaZDo8=",
             "dev": true
         },
         "binary-extensions": {
@@ -1255,7 +311,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -1266,9 +322,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-stdout": {
@@ -1277,61 +333,18 @@
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
-        "buffer-from": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-            "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-            "dev": true
-        },
-        "caller-path": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-            "dev": true,
-            "requires": {
-                "callsites": "0.2.0"
-            }
-        },
-        "callsites": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-            "dev": true
-        },
-        "camelcase": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-            "dev": true
-        },
-        "center-align": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-            "dev": true,
-            "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
-            }
-        },
         "chalk": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
-        },
-        "chardet": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-            "dev": true
         },
         "chokidar": {
             "version": "1.7.0",
@@ -1340,69 +353,16 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "anymatch": "1.3.2",
-                "async-each": "1.0.1",
-                "fsevents": "1.2.2",
-                "glob-parent": "2.0.0",
-                "inherits": "2.0.1",
-                "is-binary-path": "1.0.1",
-                "is-glob": "2.0.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0"
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
             }
-        },
-        "circular-json": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-            "dev": true
-        },
-        "cli-cursor": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-            "dev": true,
-            "requires": {
-                "restore-cursor": "2.0.0"
-            }
-        },
-        "cli-width": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-            "dev": true
-        },
-        "cliui": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-            "dev": true,
-            "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
-                "wordwrap": "0.0.2"
-            }
-        },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true
-        },
-        "color-convert": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-            "dev": true,
-            "requires": {
-                "color-name": "1.1.3"
-            }
-        },
-        "color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
         },
         "commander": {
             "version": "2.15.1",
@@ -1415,26 +375,6 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
-        },
-        "concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
-            "requires": {
-                "buffer-from": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
-            },
-            "dependencies": {
-                "inherits": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "dev": true
-                }
-            }
         },
         "convert-source-map": {
             "version": "1.5.1",
@@ -1452,18 +392,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
-        },
-        "cross-spawn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
-            "requires": {
-                "lru-cache": "4.1.2",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
-            }
+            "optional": true
         },
         "debug": {
             "version": "2.6.9",
@@ -1474,40 +404,13 @@
                 "ms": "2.0.0"
             }
         },
-        "decamelize": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-            "dev": true
-        },
-        "deep-is": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-            "dev": true
-        },
-        "del": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-            "dev": true,
-            "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
-            }
-        },
         "detect-indent": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "diff": {
@@ -1516,197 +419,10 @@
             "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
             "dev": true
         },
-        "doctrine": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-            "dev": true,
-            "requires": {
-                "esutils": "2.0.2"
-            }
-        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
-        },
-        "eslint": {
-            "version": "4.19.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-            "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
-            "dev": true,
-            "requires": {
-                "ajv": "5.5.2",
-                "babel-code-frame": "6.26.0",
-                "chalk": "2.4.1",
-                "concat-stream": "1.6.2",
-                "cross-spawn": "5.1.0",
-                "debug": "3.1.0",
-                "doctrine": "2.1.0",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "1.0.0",
-                "espree": "3.5.4",
-                "esquery": "1.0.1",
-                "esutils": "2.0.2",
-                "file-entry-cache": "2.0.0",
-                "functional-red-black-tree": "1.0.1",
-                "glob": "7.1.2",
-                "globals": "11.4.0",
-                "ignore": "3.3.8",
-                "imurmurhash": "0.1.4",
-                "inquirer": "3.3.0",
-                "is-resolvable": "1.1.0",
-                "js-yaml": "3.11.0",
-                "json-stable-stringify-without-jsonify": "1.0.1",
-                "levn": "0.3.0",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "optionator": "0.8.2",
-                "path-is-inside": "1.0.2",
-                "pluralize": "7.0.0",
-                "progress": "2.0.0",
-                "regexpp": "1.1.0",
-                "require-uncached": "1.0.3",
-                "semver": "5.5.0",
-                "strip-ansi": "4.0.0",
-                "strip-json-comments": "2.0.1",
-                "table": "4.0.2",
-                "text-table": "0.2.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
-                    }
-                },
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "globals": {
-                    "version": "11.4.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-                    "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "3.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "3.0.0"
-                    }
-                }
-            }
-        },
-        "eslint-plugin-babel": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.1.0.tgz",
-            "integrity": "sha512-HBkv9Q0LU/IhNUauC8TrbhcN79Yq/+xh2bYTOcv6KMaV2tsvVphkHwDTJ9r3C6mJUnmxrtzT3DQfrWj0rOISqQ==",
-            "dev": true,
-            "requires": {
-                "eslint-rule-composer": "0.3.0"
-            }
-        },
-        "eslint-rule-composer": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
-            "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-            "dev": true
-        },
-        "eslint-scope": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-            "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-            "dev": true,
-            "requires": {
-                "esrecurse": "4.2.1",
-                "estraverse": "4.2.0"
-            }
-        },
-        "eslint-visitor-keys": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-            "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-            "dev": true
-        },
-        "espree": {
-            "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-            "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-            "dev": true,
-            "requires": {
-                "acorn": "5.5.3",
-                "acorn-jsx": "3.0.1"
-            }
-        },
-        "esprima": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-            "dev": true
-        },
-        "esquery": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-            "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
-            "dev": true,
-            "requires": {
-                "estraverse": "4.2.0"
-            }
-        },
-        "esrecurse": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-            "dev": true,
-            "requires": {
-                "estraverse": "4.2.0"
-            }
-        },
-        "estraverse": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
             "dev": true
         },
         "esutils": {
@@ -1722,7 +438,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -1732,18 +448,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "fill-range": "2.2.3"
-            }
-        },
-        "external-editor": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-            "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-            "dev": true,
-            "requires": {
-                "chardet": "0.4.2",
-                "iconv-lite": "0.4.21",
-                "tmp": "0.0.33"
+                "fill-range": "^2.1.0"
             }
         },
         "extglob": {
@@ -1753,44 +458,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "is-extglob": "1.0.0"
-            }
-        },
-        "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-            "dev": true
-        },
-        "fast-json-stable-stringify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-            "dev": true
-        },
-        "fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-            "dev": true
-        },
-        "figures": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "1.0.5"
-            }
-        },
-        "file-entry-cache": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-            "dev": true,
-            "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
+                "is-extglob": "^1.0.0"
             }
         },
         "filename-regex": {
@@ -1807,23 +475,11 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
-            }
-        },
-        "flat-cache": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-            "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-            "dev": true,
-            "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "for-in": {
@@ -1840,7 +496,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "fs-readdir-recursive": {
@@ -1862,8 +518,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.9.1"
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.9.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -1889,8 +545,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "balanced-match": {
@@ -1903,7 +559,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -1967,7 +623,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "fs.realpath": {
@@ -1982,14 +638,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "glob": {
@@ -1998,12 +654,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-unicode": {
@@ -2018,7 +674,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "ignore-walk": {
@@ -2027,7 +683,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "3.0.4"
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "inflight": {
@@ -2036,8 +692,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -2056,7 +712,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -2070,7 +726,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -2083,8 +739,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
@@ -2093,7 +749,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "mkdirp": {
@@ -2116,9 +772,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "iconv-lite": "0.4.21",
-                        "sax": "1.2.4"
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -2127,16 +783,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.3",
-                        "mkdirp": "0.5.1",
-                        "needle": "2.2.0",
-                        "nopt": "4.0.1",
-                        "npm-packlist": "1.1.10",
-                        "npmlog": "4.1.2",
-                        "rc": "1.2.6",
-                        "rimraf": "2.6.2",
-                        "semver": "5.5.0",
-                        "tar": "4.4.1"
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
                     }
                 },
                 "nopt": {
@@ -2145,8 +801,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npm-bundled": {
@@ -2161,8 +817,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
                     }
                 },
                 "npmlog": {
@@ -2171,10 +827,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -2193,7 +849,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -2214,8 +870,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -2236,10 +892,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "~0.4.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2256,13 +912,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "rimraf": {
@@ -2271,7 +927,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -2314,9 +970,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -2325,7 +981,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -2333,7 +989,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -2348,13 +1004,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.4",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -2369,7 +1025,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2384,24 +1040,18 @@
                 }
             }
         },
-        "functional-red-black-tree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-            "dev": true
-        },
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2411,8 +1061,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "glob-parent": {
@@ -2421,7 +1071,7 @@
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
             }
         },
         "globals": {
@@ -2429,20 +1079,6 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
             "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
             "dev": true
-        },
-        "globby": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-            "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-            "dev": true,
-            "requires": {
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
-            }
         },
         "graceful-fs": {
             "version": "4.1.11",
@@ -2462,14 +1098,8 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
-        },
-        "has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
         },
         "he": {
             "version": "1.1.1",
@@ -2483,30 +1113,9 @@
             "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.1"
             }
-        },
-        "iconv-lite": {
-            "version": "0.4.21",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-            "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
-            "dev": true,
-            "requires": {
-                "safer-buffer": "2.1.2"
-            }
-        },
-        "ignore": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-            "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
-            "dev": true
-        },
-        "imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "dev": true
         },
         "inflight": {
             "version": "1.0.6",
@@ -2514,8 +1123,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -2524,81 +1133,13 @@
             "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
             "dev": true
         },
-        "inquirer": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-            "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-            "dev": true,
-            "requires": {
-                "ansi-escapes": "3.1.0",
-                "chalk": "2.4.1",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "2.2.0",
-                "figures": "2.0.0",
-                "lodash": "4.17.10",
-                "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rx-lite": "4.0.8",
-                "rx-lite-aggregates": "4.0.8",
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "through": "2.3.8"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "3.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "3.0.0"
-                    }
-                }
-            }
-        },
         "invariant": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
-                "loose-envify": "1.3.1"
+                "loose-envify": "^1.0.0"
             }
         },
         "is-binary-path": {
@@ -2608,7 +1149,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -2631,7 +1172,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -2653,14 +1194,8 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
-        },
-        "is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-            "dev": true
         },
         "is-glob": {
             "version": "2.0.1",
@@ -2668,7 +1203,7 @@
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "is-number": {
@@ -2678,31 +1213,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "kind-of": "3.2.2"
-            }
-        },
-        "is-path-cwd": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-            "dev": true
-        },
-        "is-path-in-cwd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-            "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-            "dev": true,
-            "requires": {
-                "is-path-inside": "1.0.1"
-            }
-        },
-        "is-path-inside": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-            "dev": true,
-            "requires": {
-                "path-is-inside": "1.0.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-posix-bracket": {
@@ -2719,28 +1230,10 @@
             "dev": true,
             "optional": true
         },
-        "is-promise": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-            "dev": true
-        },
-        "is-resolvable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-            "dev": true
-        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "dev": true
-        },
-        "isexe": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
         },
         "isobject": {
@@ -2759,32 +1252,10 @@
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
             "dev": true
         },
-        "js-yaml": {
-            "version": "3.11.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-            "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-            "dev": true,
-            "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.0"
-            }
-        },
         "jsesc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
             "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-            "dev": true
-        },
-        "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-            "dev": true
-        },
-        "json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
         "json5": {
@@ -2799,23 +1270,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6"
-            }
-        },
-        "lazy-cache": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-            "dev": true
-        },
-        "levn": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "is-buffer": "^1.1.5"
             }
         },
         "lodash": {
@@ -2824,29 +1279,13 @@
             "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
             "dev": true
         },
-        "longest": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-            "dev": true
-        },
         "loose-envify": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
             "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
             "dev": true,
             "requires": {
-                "js-tokens": "3.0.2"
-            }
-        },
-        "lru-cache": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-            "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-            "dev": true,
-            "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "js-tokens": "^3.0.0"
             }
         },
         "micromatch": {
@@ -2856,26 +1295,20 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             }
-        },
-        "mimic-fn": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-            "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -2883,7 +1316,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -2947,7 +1380,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -2958,12 +1391,6 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
         },
-        "mute-stream": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-            "dev": true
-        },
         "nan": {
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
@@ -2971,19 +1398,13 @@
             "dev": true,
             "optional": true
         },
-        "natural-compare": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-            "dev": true
-        },
         "normalize-path": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "number-is-nan": {
@@ -3005,8 +1426,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "once": {
@@ -3015,38 +1436,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
-            }
-        },
-        "onetime": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-            "dev": true,
-            "requires": {
-                "mimic-fn": "1.2.0"
-            }
-        },
-        "optionator": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-            "dev": true,
-            "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-            },
-            "dependencies": {
-                "wordwrap": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-                    "dev": true
-                }
+                "wrappy": "1"
             }
         },
         "os-homedir": {
@@ -3067,9 +1457,9 @@
             "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1"
+                "graceful-fs": "^4.1.4",
+                "mkdirp": "^0.5.1",
+                "object-assign": "^4.1.0"
             }
         },
         "parse-glob": {
@@ -3079,55 +1469,16 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
-        },
-        "path-is-inside": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-            "dev": true
-        },
-        "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true
-        },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
-            "requires": {
-                "pinkie": "2.0.4"
-            }
-        },
-        "pluralize": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-            "dev": true
-        },
-        "prelude-ls": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
             "dev": true
         },
         "preserve": {
@@ -3147,19 +1498,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
             "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-            "dev": true
-        },
-        "progress": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-            "dev": true
-        },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "randomatic": {
             "version": "1.1.7",
@@ -3168,8 +1508,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -3179,7 +1519,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -3189,7 +1529,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -3201,7 +1541,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3211,21 +1551,23 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
+            "optional": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             },
             "dependencies": {
                 "inherits": {
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                     "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -3236,34 +1578,17 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.6",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
-        },
-        "regenerate": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-            "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
-            "dev": true
         },
         "regenerator-runtime": {
             "version": "0.11.1",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
             "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
             "dev": true
-        },
-        "regenerator-transform": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-            "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "private": "0.1.8"
-            }
         },
         "regex-cache": {
             "version": "0.4.4",
@@ -3272,47 +1597,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
-            }
-        },
-        "regexpp": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-            "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
-            "dev": true
-        },
-        "regexpu-core": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-            "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-            "dev": true,
-            "requires": {
-                "regenerate": "1.3.3",
-                "regjsgen": "0.2.0",
-                "regjsparser": "0.1.5"
-            }
-        },
-        "regjsgen": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-            "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-            "dev": true
-        },
-        "regjsparser": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-            "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-            "dev": true,
-            "requires": {
-                "jsesc": "0.5.0"
-            },
-            "dependencies": {
-                "jsesc": {
-                    "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-                    "dev": true
-                }
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "remove-trailing-separator": {
@@ -3331,7 +1616,8 @@
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "repeating": {
             "version": "2.0.1",
@@ -3339,93 +1625,13 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "1.0.2"
-            }
-        },
-        "require-uncached": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-            "dev": true,
-            "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
-            }
-        },
-        "resolve-from": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-            "dev": true
-        },
-        "restore-cursor": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-            "dev": true,
-            "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
-            }
-        },
-        "right-align": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-            "dev": true,
-            "requires": {
-                "align-text": "0.1.4"
-            }
-        },
-        "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-            "dev": true,
-            "requires": {
-                "glob": "7.1.2"
-            }
-        },
-        "run-async": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-            "dev": true,
-            "requires": {
-                "is-promise": "2.1.0"
-            }
-        },
-        "rx-lite": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-            "dev": true
-        },
-        "rx-lite-aggregates": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-            "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-            "dev": true,
-            "requires": {
-                "rx-lite": "4.0.8"
+                "is-finite": "^1.0.0"
             }
         },
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
-        },
-        "semver": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
             "dev": true
         },
         "set-immediate-shim": {
@@ -3435,41 +1641,11 @@
             "dev": true,
             "optional": true
         },
-        "shebang-command": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true,
-            "requires": {
-                "shebang-regex": "1.0.0"
-            }
-        },
-        "shebang-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
-        },
-        "signal-exit": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-            "dev": true
-        },
         "slash": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
             "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
             "dev": true
-        },
-        "slice-ansi": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-            "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-            "dev": true,
-            "requires": {
-                "is-fullwidth-code-point": "2.0.0"
-            }
         },
         "source-map": {
             "version": "0.5.7",
@@ -3483,40 +1659,7 @@
             "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
-            }
-        },
-        "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
-        },
-        "string-width": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "dev": true,
-            "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "3.0.0"
-                    }
-                }
+                "source-map": "^0.5.6"
             }
         },
         "string_decoder": {
@@ -3524,8 +1667,9 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
+            "optional": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
@@ -3534,86 +1678,14 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
-        },
-        "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "dev": true
         },
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
-        },
-        "table": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-            "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-            "dev": true,
-            "requires": {
-                "ajv": "5.5.2",
-                "ajv-keywords": "2.1.1",
-                "chalk": "2.4.1",
-                "lodash": "4.17.10",
-                "slice-ansi": "1.0.0",
-                "string-width": "2.1.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "3.0.0"
-                    }
-                }
-            }
-        },
-        "text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true
-        },
-        "through": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
-        },
-        "tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "requires": {
-                "os-tmpdir": "1.0.2"
-            }
         },
         "to-fast-properties": {
             "version": "1.0.3",
@@ -3626,39 +1698,6 @@
             "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
-        },
-        "type-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "1.1.2"
-            }
-        },
-        "typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-            "dev": true
-        },
-        "uglify-js": {
-            "version": "2.8.29",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-            "dev": true,
-            "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
-            }
-        },
-        "uglify-to-browserify": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-            "dev": true,
-            "optional": true
         },
         "user-home": {
             "version": "1.1.1",
@@ -3679,7 +1718,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "v8flags": {
             "version": "2.1.1",
@@ -3687,62 +1727,14 @@
             "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
             "dev": true,
             "requires": {
-                "user-home": "1.1.1"
+                "user-home": "^1.1.1"
             }
-        },
-        "which": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-            "dev": true,
-            "requires": {
-                "isexe": "2.0.0"
-            }
-        },
-        "window-size": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-            "dev": true
-        },
-        "wordwrap": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-            "dev": true
         },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
-        },
-        "write": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-            "dev": true,
-            "requires": {
-                "mkdirp": "0.5.1"
-            }
-        },
-        "yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-            "dev": true
-        },
-        "yargs": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-            "dev": true,
-            "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
-                "window-size": "0.1.0"
-            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,40 +1,31 @@
 {
-    "name": "every-fn",
-    "version": "1.0.4",
-    "description": "Helper that runs each function in a list until one fails",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/ryan-mahoney/Every-Fn"
-    },
-    "author": "Ryan Mahoney",
-    "license": "MIT",
-    "homepage": "https://github.com/ryan-mahoney/Every-Fn",
-    "keywords": [
-        "helper"
-    ],
-    "main": "dist/index.js",
-    "scripts": {
-        "build": "node_modules/babel-cli/bin/babel.js --plugins 'transform-es2015-modules-umd' src --out-dir ./dist",
-        "lint": "eslint ./src",
-        "lintfix": "eslint ./src --fix",
-        "test": "node_modules/mocha/bin/mocha --require babel-core/register"
-    },
-    "devDependencies": {
-        "babel-cli": "^6.26.0",
-        "babel-core": "^6.26.0",
-        "babel-eslint": "^8.2.3",
-        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-        "babel-polyfill": "^6.26.0",
-        "babel-preset-es2015": "^6.24.1",
-        "babel-preset-stage-0": "^6.24.1",
-        "babel-preset-stage-2": "^6.24.1",
-        "babel-plugin-transform-runtime": "^6.23.0",
-        "babel-plugin-uglify": "^1.0.2",
-        "eslint": "^4.19.1",
-        "eslint-plugin-babel": "^5.0.0",
-        "mocha": "^5.1.0",
-        "assert": "^1.4.1"
-    },
-    "peerDependencies": {},
-    "dependencies": {}
+  "name": "every-fn",
+  "version": "1.0.5",
+  "description": "Helper that runs each function in a list until one fails",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryan-mahoney/Every-Fn"
+  },
+  "author": "Ryan Mahoney",
+  "license": "MIT",
+  "homepage": "https://github.com/ryan-mahoney/Every-Fn",
+  "keywords": [
+    "helper"
+  ],
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "node_modules/babel-cli/bin/babel.js src --out-dir ./dist",
+    "test": "node_modules/mocha/bin/mocha --require babel-core/register"
+  },
+  "devDependencies": {
+    "assert": "^1.4.1",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
+    "babel-plugin-transform-es2015-modules-simple-commonjs": "^0.3.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "mocha": "^5.1.0"
+  },
+  "peerDependencies": {
+    "objectmodel": "^3.5.4"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import { FunctionModel, Model } from "objectmodel";
+
 const handleReturnValue = (value, prevState) =>
   typeof value === "object"
     ? [true, Object.assign({}, prevState, value)]
@@ -6,10 +8,13 @@ const handleReturnValue = (value, prevState) =>
 const callFunction = async (fn, state) =>
   handleReturnValue(await fn(state), state);
 
-export default async (functions, initialState = {}) => {
+export const every = async (functions, initialState = {}) => {
   const finalState = await functions.reduce(async (previousPromise, fn) => {
     const [doNext, state] = await previousPromise;
     return doNext ? await callFunction(fn, state) : [false, state];
   }, Promise.resolve([true, initialState]));
   return finalState[1];
 };
+
+export const typed = (typeIn, typeOut, fn) =>
+  FunctionModel(Model(typeIn)).return(Model(typeOut))(fn);

--- a/src/index.js
+++ b/src/index.js
@@ -17,4 +17,6 @@ export const every = async (functions, initialState = {}) => {
 };
 
 export const typed = (typeIn, typeOut, fn) =>
-  FunctionModel(Model(typeIn)).return(Model(typeOut))(fn);
+  fn === undefined
+    ? FunctionModel(Model(typeIn))(typeOut)
+    : FunctionModel(Model(typeIn)).return(Model(typeOut))(fn);

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -63,6 +63,22 @@ describe("typed/3", () => {
     })
   );
 
+  const nameLengthAsync = typed({ name: String }, async ({ name }) => ({
+    count: name.length
+  }));
+
+  const nameLengthAsyncReturnCheck = typed(
+    { name: String },
+    { count: Number },
+    async ({ name }) => ({
+      count: await new Promise(resolve =>
+        setTimeout(() => {
+          resolve(name.length);
+        }, 100)
+      )
+    })
+  );
+
   it("returns correct length", () => {
     const { count } = nameLength({ name: "Javascript" });
     assert.equal(count, 10);
@@ -78,5 +94,16 @@ describe("typed/3", () => {
     assert.throws(() => {
       nameLengthBadReturn({ name: "Javascript" });
     }, /TypeError: expecting return value\.count to be Number, got String "Hello"/);
+  });
+
+  it("validates only input of an async function", async () => {
+    const { count } = await nameLengthAsync({ name: "Javascript" });
+    assert.equal(count, 10);
+  });
+
+  it("can not handle return check of async function", () => {
+    assert.throws(() => {
+      nameLengthAsyncReturnCheck({ name: "Javascript" });
+    }, /TypeError: expecting return value\.count to be Number, got undefined/);
   });
 });

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,11 +1,11 @@
 import assert from "assert";
-import everyFn from "./../src/index";
+import { every, typed } from "./../src/index";
 
-describe("helper", () => {
+describe("every/2", () => {
   it("allows last function", () => {
     let executed = false;
     const input = [() => true, () => true, () => (executed = true)];
-    everyFn(input).then(() => {
+    every(input).then(() => {
       assert.equal(executed, true);
     });
   });
@@ -13,7 +13,7 @@ describe("helper", () => {
   it("skips last function", () => {
     let executed = false;
     const input = [() => true, () => false, () => (executed = true)];
-    everyFn(input).then(() => {
+    every(input).then(() => {
       assert.equal(executed, false);
     });
   });
@@ -28,7 +28,7 @@ describe("helper", () => {
         total = context.value * 5;
       }
     ];
-    everyFn(input).then(() => {
+    every(input).then(() => {
       assert.equal(total, 10);
     });
   });
@@ -37,15 +37,46 @@ describe("helper", () => {
     let actual;
     const expected = { a: 10, b: 10 };
     const input = [() => ({ a: 5, b: 10 }), context => ({ a: 10 })];
-    everyFn(input).then((actual) => {
+    every(input).then(actual => {
       assert.deepEqual(expected, actual);
     });
   });
 
   it("utilizes initial state", () => {
     const expected = { a: true };
-    everyFn([], expected).then((actual) => {
+    every([], expected).then(actual => {
       assert.deepEqual(expected, actual);
     });
+  });
+});
+
+describe("typed/3", () => {
+  const nameLength = typed({ name: String }, { count: Number }, ({ name }) => ({
+    count: name.length
+  }));
+
+  const nameLengthBadReturn = typed(
+    { name: String },
+    { count: Number },
+    ({ name }) => ({
+      count: "Hello"
+    })
+  );
+
+  it("returns correct length", () => {
+    const { count } = nameLength({ name: "Javascript" });
+    assert.equal(count, 10);
+  });
+
+  it("returns type error on input", () => {
+    assert.throws(() => {
+      nameLength({ name: 100 });
+    }, /TypeError: expecting arguments\[0\]\.name to be String, got Number 100/);
+  });
+
+  it("returns type error on output", () => {
+    assert.throws(() => {
+      nameLengthBadReturn({ name: "Javascript" });
+    }, /TypeError: expecting return value\.count to be Number, got String "Hello"/);
   });
 });


### PR DESCRIPTION
- generate smaller build
- minor documentation updates
- export `every` and `typed` separately
- add `typed` function helper for enabling runtime type checking
- add additional test coverage
- remove unused dependencies
- make `objectmodel` a peer dependency